### PR TITLE
Optimize the clone() system call on ARM(64)

### DIFF
--- a/libc/arch-arm/bionic/__bionic_clone.S
+++ b/libc/arch-arm/bionic/__bionic_clone.S
@@ -42,9 +42,6 @@ ENTRY_PRIVATE(__bionic_clone)
     # load extra parameters
     ldmfd   ip, {r4, r5, r6}
 
-    # Push 'fn' and 'arg' onto the child stack.
-    stmdb   r1!, {r5, r6}
-
     # Make the system call.
     ldr     r7, =__NR_clone
     swi     #0
@@ -65,7 +62,8 @@ ENTRY_PRIVATE(__bionic_clone)
     mov    fp, #0
     # Setting lr to 0 will make the unwinder stop at __start_thread.
     mov    lr, #0
-    # Call __start_thread with the 'fn' and 'arg' we stored on the child stack.
-    pop    {r0, r1}
+    # Call __start_thread with the 'fn' and 'arg' parameters.
+    mov    r0, r5
+    mov    r1, r6
     b      __start_thread
 END(__bionic_clone)

--- a/libc/arch-arm64/bionic/__bionic_clone.S
+++ b/libc/arch-arm64/bionic/__bionic_clone.S
@@ -31,9 +31,6 @@
 // pid_t __bionic_clone(int flags, void* child_stack, pid_t* parent_tid, void* tls, pid_t* child_tid, int (*fn)(void*), void* arg);
 
 ENTRY_PRIVATE(__bionic_clone)
-    # Push 'fn' and 'arg' onto the child stack.
-    stp     x5, x6, [x1, #-16]!
-
     # Make the system call.
     mov     x8, __NR_clone
     svc     #0
@@ -53,8 +50,9 @@ ENTRY_PRIVATE(__bionic_clone)
     mov     x29, #0
     # Setting x30 to 0 will make the unwinder stop at __start_thread.
     mov     x30, #0
-    # Call __start_thread with the 'fn' and 'arg' we stored on the child stack.
-    ldp     x0, x1, [sp], #16
+    # Call __start_thread with the 'fn' and 'arg' parameters.
+    mov     x0, x5
+    mov     x1, x6
     b       __start_thread
 END(__bionic_clone)
 


### PR DESCRIPTION
The kernel preserves all register values except R0/X0 and SP, so there is no need to push arguments on the stack.

Test: bionic unit tests on device
Change-Id: I027c2f166e937fbd4448c62c0a0c706ba049e02e
Signed-off-by: mydongistiny <jaysonedson@gmail.com>
Signed-off-by: blinoff82 <blinov.in@gmail.com>